### PR TITLE
Generates a member key on level change

### DIFF
--- a/pmpro-member-rss.php
+++ b/pmpro-member-rss.php
@@ -129,7 +129,7 @@ function pmprorss_pmpro_rss_text_filter($text)
 {
 	global $post;
 	
-	$text = "Please visit " . get_permalink($post->ID) . " to access this member content.";
+	$text = sprintf( __( 'Please visit %s to access this member content.', 'pmpro-member-rss' ), get_permalink( $post->ID ) );
 	
 	return $text;
 }
@@ -149,3 +149,20 @@ function pmprorss_plugin_row_meta($links, $file) {
 	return $links;
 }
 add_filter('plugin_row_meta', 'pmprorss_plugin_row_meta', 10, 2);
+
+/**
+ * Generates the member key after the level has changed
+ *
+ * @param $level_id int Level ID being changed to
+ * @param $user_id int User ID this relates to
+ * @param $cancel_id int Level ID that is being cancelled
+ * 
+ * @since TBD
+ * @return void
+ */
+function pmprorss_after_level_change_generate_key( $level_id, $user_id, $cancel ) {
+
+	pmpromrss_getMemberKey( $user_id );
+
+}
+add_action( 'pmpro_after_change_membership_level', 'pmprorss_after_level_change_generate_key', 10, 3 );


### PR DESCRIPTION
Generates the member key on level change to ensure a key is present even if you don't visit the Membership Account page

Relates to https://github.com/strangerstudios/pmpro-member-rss/issues/3