### PR TITLE
Updating headings for a11y

### DIFF
--- a/pmpro-member-rss.php
+++ b/pmpro-member-rss.php
@@ -196,7 +196,7 @@ function pmprorss_memberkeys_profile( $user ) {
 	);
 	?>
 
-    <h3><?php esc_html_e( 'Member RSS', 'pmpro-member-rss' ); ?></h3>
+    <h2><?php esc_html_e( 'Member RSS', 'pmpro-member-rss' ); ?></h2>
 
     <table class="form-table">
 


### PR DESCRIPTION
PMPro v2.11 updated the checkout page headings hierarchy from h3 to h2. This PR updates this Add On to follow the same pattern for accessibility.