### PR TITLE
Feed filter was never running.

### DIFF
--- a/pmpro-member-rss.php
+++ b/pmpro-member-rss.php
@@ -76,21 +76,42 @@ add_action('pmpro_member_links_bottom', 'pmpromrss_pmpro_member_links_bottom');
 /*
 	Check for Member Key and Disable Content Filter in RSS Feed Items
 */
-//only filter if a valid member key is present
-function pmprorss_init() {	
-	global $wpdb, $pmpromrss_user_id, $wp_query;
-	if( ! empty( $_REQUEST['memberkey'] ) ) {		
-		$key = preg_replace( '[0-9a-f]', '', $_REQUEST['memberkey'] );
-		$pmpromrss_user_id = $wpdb->get_var("SELECT user_id FROM $wpdb->usermeta WHERE meta_key = 'pmpromrss_key' AND meta_value = '" . esc_sql($key) . "' LIMIT 1");
+/**
+ * Set up the member RSS key user ID early if present.
+ */
+function pmprorss_init() {
+	global $wpdb, $pmpromrss_user_id;
 
-		// Use our search filter if PMPro set one up.
-		if ( $wp_query->is_feed && has_filter( 'pre_get_posts', 'pmpro_search_filter' ) ) {
-			remove_filter( 'pre_get_posts', 'pmpro_search_filter' );
-			add_filter( 'pre_get_posts', 'pmprorss_search_filter' );	
-		}
-	}	
+	if ( ! empty( $_REQUEST['memberkey'] ) ) {
+		$key = preg_replace( '/[^0-9a-f]/', '', $_REQUEST['memberkey'] );
+		$pmpromrss_user_id = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT user_id FROM $wpdb->usermeta WHERE meta_key = 'pmpromrss_key' AND meta_value = %s LIMIT 1",
+				$key
+			)
+		);
+	}
 }
-add_action('init', 'pmprorss_init', 1);
+add_action( 'init', 'pmprorss_init', 1 );
+
+/**
+ * Filter feed queries to use the member key user's access.
+ */
+function pmprorss_pre_get_posts( $query ) {
+	global $pmpromrss_user_id;
+
+	// Only filter feed queries with a valid member key.
+	if ( empty( $pmpromrss_user_id ) || ! $query->is_feed() ) {
+		return;
+	}
+
+	// Remove PMPro's search filter for this feed query and add ours.
+	if ( has_filter( 'pre_get_posts', 'pmpro_search_filter' ) ) {
+		remove_filter( 'pre_get_posts', 'pmpro_search_filter' );
+		add_filter( 'pre_get_posts', 'pmprorss_search_filter' );
+	}
+}
+add_action( 'pre_get_posts', 'pmprorss_pre_get_posts', 0 );
 
 /**
  * Override the current user when running search queries.


### PR DESCRIPTION
WP can load multiple wp_query instances on a single page load. On my basic set up environment, this meant that on init $wp_query->is_feed was false and so the feed filter was never set up.

This code now just sets the member key user id on init and filters specific feed queries.

It overrides all wp queries after the first feed one is found, which I think is generally okay since on /feed/ we should only have one main query.

But we should perhaps clean up after ourselves and set the filters back to normal when we are filtering a non feed query.

I think this update also loses the check to see if our "filter archives and searches" setting is even on, which we maybe want to bring back.